### PR TITLE
Order matters

### DIFF
--- a/trouble/CMakeLists.txt
+++ b/trouble/CMakeLists.txt
@@ -44,15 +44,15 @@ add_custom_command(TARGET ${PROJECT_NAME}
 
 add_custom_command(TARGET ${PROJECT_NAME}
                    POST_BUILD
-                   COMMAND ../cryptor/cryptor ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME})
-
-add_custom_command(TARGET ${PROJECT_NAME}
-                   POST_BUILD
                    COMMAND ../stripBinary/stripBinary ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME})
 
 add_custom_command(TARGET ${PROJECT_NAME}
                    POST_BUILD
                    COMMAND ../fakeHeadersXBit/fakeHeadersXBit ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME})
+
+add_custom_command(TARGET ${PROJECT_NAME}
+                   POST_BUILD
+                   COMMAND ../cryptor/cryptor ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME})
 
 add_custom_command(TARGET ${PROJECT_NAME}
                    POST_BUILD


### PR DESCRIPTION
Fooling around with Yara, I realized the order of the obfuscations is not right. "cryptor" must be applied after "fakeHeadersXbit" or a negative size for .data is in the fake section headers table is probable.